### PR TITLE
Update package.json for newer hapi versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "prettier": "^2.2.1"
   },
   "peerDependencies": {
-    "@hapi/hapi": ">=17.0.0 <21.0.0"
+    "@hapi/hapi": ">=17.0.0 <22.0.0"
   }
 }


### PR DESCRIPTION
Just a hapi version bump to support the current 21.3.12 build of hapi